### PR TITLE
Add event subject to forms and templates

### DIFF
--- a/meetup_clone/app/forms.py
+++ b/meetup_clone/app/forms.py
@@ -7,6 +7,7 @@ class EventForm(FlaskForm):
     description = TextAreaField('Description')
     date = DateTimeField('Date and Time', format='%Y-%m-%d %H:%M', validators=[DataRequired()])
     location = StringField('Location', validators=[Length(max=100)])
+    subject = StringField('Subject', validators=[Length(max=100)])
     submit = SubmitField('Create Event')
 
 class RegisterForm(FlaskForm):

--- a/meetup_clone/app/models.py
+++ b/meetup_clone/app/models.py
@@ -22,6 +22,7 @@ class Event(db.Model):
     description = db.Column(db.Text)
     date = db.Column(db.DateTime, nullable=False)
     location = db.Column(db.String(100))
+    subject = db.Column(db.String(100))
     organizer_id = db.Column(db.Integer, db.ForeignKey('user.id'), nullable=False)
 
 @login_manager.user_loader

--- a/meetup_clone/app/routes.py
+++ b/meetup_clone/app/routes.py
@@ -21,6 +21,7 @@ def create_event():
                       description=form.description.data,
                       date=form.date.data,
                       location=form.location.data,
+                      subject=form.subject.data,
                       organizer=current_user)
         db.session.add(event)
         db.session.commit()

--- a/meetup_clone/app/templates/create_event.html
+++ b/meetup_clone/app/templates/create_event.html
@@ -29,6 +29,12 @@
         </div>
     </div>
     <div class="field">
+        {{ form.subject.label(class="label") }}
+        <div class="control">
+            {{ form.subject(class="input") }}
+        </div>
+    </div>
+    <div class="field">
         <div class="control">
             {{ form.submit(class="button is-primary") }}
         </div>

--- a/meetup_clone/app/templates/event_details.html
+++ b/meetup_clone/app/templates/event_details.html
@@ -5,6 +5,7 @@
 <p class="subtitle">{{ event.date.strftime('%Y年%m月%d日 %H:%M') }}</p>
 <p><strong>場所:</strong> {{ event.location }}</p>
 <p><strong>主催者:</strong> {{ event.organizer.username }}</p>
+<p><strong>テーマ:</strong> {{ event.subject }}</p>
 <div class="content">
     {{ event.description }}
 </div>

--- a/meetup_clone/app/templates/home.html
+++ b/meetup_clone/app/templates/home.html
@@ -10,6 +10,7 @@
                 <p class="title is-4">{{ event.title }}</p>
                 <p class="subtitle is-6">{{ event.date.strftime('%Y年%m月%d日 %H:%M') }}</p>
                 <p>{{ event.location }}</p>
+                <p>{{ event.subject }}</p>
             </div>
             <footer class="card-footer">
                 <a href="{{ url_for('main.event_details', event_id=event.id) }}" class="card-footer-item">詳細を見る</a>


### PR DESCRIPTION
Add subject field to events to help recommend appropriate events based on subject.

* **Forms**: Add `subject` field to `EventForm` class in `meetup_clone/app/forms.py`.
* **Models**: Add `subject` column to `Event` model in `meetup_clone/app/models.py`.
* **Routes**: Update `create_event` route to include `subject` field in `meetup_clone/app/routes.py`.
* **Templates**:
  - Add input field for `subject` in the form in `meetup_clone/app/templates/create_event.html`.
  - Display `subject` in event details in `meetup_clone/app/templates/event_details.html`.
  - Display `subject` in event cards in `meetup_clone/app/templates/home.html`.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/magusCoder-official/japanese-meetup-clone?shareId=ff8d600c-d110-44a0-86bc-cf97c5b39e20).