### PR TITLE
Add host and sub host details to event creation and sign up

### DIFF
--- a/meetup_clone/app/forms.py
+++ b/meetup_clone/app/forms.py
@@ -7,11 +7,16 @@ class EventForm(FlaskForm):
     description = TextAreaField('Description')
     date = DateTimeField('Date and Time', format='%Y-%m-%d %H:%M', validators=[DataRequired()])
     location = StringField('Location', validators=[Length(max=100)])
+    host_email = StringField('Host Email', validators=[DataRequired(), Email()])
+    host_phone = StringField('Host Phone', validators=[DataRequired(), Length(max=15)])
+    sub_host_email = StringField('Sub Host Email', validators=[Email()])
+    sub_host_phone = StringField('Sub Host Phone', validators=[Length(max=15)])
     submit = SubmitField('Create Event')
 
 class RegisterForm(FlaskForm):
     username = StringField('Username', validators=[DataRequired(), Length(min=4, max=25)])
     email = StringField('Email', validators=[DataRequired(), Email()])
+    phone = StringField('Phone', validators=[DataRequired(), Length(max=15)])
     password = PasswordField('Password', validators=[DataRequired(), Length(min=6)])
     submit = SubmitField('Sign Up')
 

--- a/meetup_clone/app/models.py
+++ b/meetup_clone/app/models.py
@@ -7,6 +7,7 @@ class User(UserMixin, db.Model):
     id = db.Column(db.Integer, primary_key=True)
     username = db.Column(db.String(64), unique=True, nullable=False)
     email = db.Column(db.String(120), unique=True, nullable=False)
+    phone = db.Column(db.String(15), nullable=False)
     password_hash = db.Column(db.String(128))
     events = db.relationship('Event', backref='organizer', lazy='dynamic')
 
@@ -22,6 +23,10 @@ class Event(db.Model):
     description = db.Column(db.Text)
     date = db.Column(db.DateTime, nullable=False)
     location = db.Column(db.String(100))
+    host_email = db.Column(db.String(120), nullable=False)
+    host_phone = db.Column(db.String(15), nullable=False)
+    sub_host_email = db.Column(db.String(120))
+    sub_host_phone = db.Column(db.String(15))
     organizer_id = db.Column(db.Integer, db.ForeignKey('user.id'), nullable=False)
 
 @login_manager.user_loader

--- a/meetup_clone/app/routes.py
+++ b/meetup_clone/app/routes.py
@@ -21,6 +21,10 @@ def create_event():
                       description=form.description.data,
                       date=form.date.data,
                       location=form.location.data,
+                      host_email=form.host_email.data,
+                      host_phone=form.host_phone.data,
+                      sub_host_email=form.sub_host_email.data,
+                      sub_host_phone=form.sub_host_phone.data,
                       organizer=current_user)
         db.session.add(event)
         db.session.commit()
@@ -37,7 +41,7 @@ def event_details(event_id):
 def register():
     form = RegisterForm()
     if form.validate_on_submit():
-        user = User(username=form.username.data, email=form.email.data)
+        user = User(username=form.username.data, email=form.email.data, phone=form.phone.data)
         user.set_password(form.password.data)
         db.session.add(user)
         db.session.commit()

--- a/meetup_clone/app/templates/create_event.html
+++ b/meetup_clone/app/templates/create_event.html
@@ -29,6 +29,30 @@
         </div>
     </div>
     <div class="field">
+        {{ form.host_email.label(class="label") }}
+        <div class="control">
+            {{ form.host_email(class="input") }}
+        </div>
+    </div>
+    <div class="field">
+        {{ form.host_phone.label(class="label") }}
+        <div class="control">
+            {{ form.host_phone(class="input") }}
+        </div>
+    </div>
+    <div class="field">
+        {{ form.sub_host_email.label(class="label") }}
+        <div class="control">
+            {{ form.sub_host_email(class="input") }}
+        </div>
+    </div>
+    <div class="field">
+        {{ form.sub_host_phone.label(class="label") }}
+        <div class="control">
+            {{ form.sub_host_phone(class="input") }}
+        </div>
+    </div>
+    <div class="field">
         <div class="control">
             {{ form.submit(class="button is-primary") }}
         </div>

--- a/meetup_clone/app/templates/register.html
+++ b/meetup_clone/app/templates/register.html
@@ -17,6 +17,12 @@
         </div>
     </div>
     <div class="field">
+        {{ form.phone.label(class="label") }}
+        <div class="control">
+            {{ form.phone(class="input") }}
+        </div>
+    </div>
+    <div class="field">
         {{ form.password.label(class="label") }}
         <div class="control">
             {{ form.password(class="input") }}


### PR DESCRIPTION
Add host and sub host details to event creation and user registration forms.

* **Forms**:
  - Add `host_email`, `host_phone`, `sub_host_email`, and `sub_host_phone` fields to `EventForm`.
  - Add `phone` field to `RegisterForm`.

* **Models**:
  - Add `phone` field to `User` model.
  - Add `host_email`, `host_phone`, `sub_host_email`, and `sub_host_phone` fields to `Event` model.

* **Routes**:
  - Update `create_event` route to handle new fields in `EventForm`.
  - Update `register` route to handle new `phone` field in `RegisterForm`.

* **Templates**:
  - Add input fields for `host_email`, `host_phone`, `sub_host_email`, and `sub_host_phone` in `create_event.html`.
  - Add input field for `phone` in `register.html`.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/magusCoder-official/japanese-meetup-clone?shareId=a8663dbd-5b46-4310-b594-c8a9fa89435e).