### PR TITLE
Filter events by location and date

### DIFF
--- a/meetup_clone/app/routes.py
+++ b/meetup_clone/app/routes.py
@@ -3,13 +3,25 @@ from flask_login import login_required, current_user, login_user, logout_user
 from app.models import Event, User
 from app.forms import EventForm, RegisterForm, LoginForm
 from app import db
+from datetime import datetime
+import random
 
 main = Blueprint('main', __name__)
 auth = Blueprint('auth', __name__)
 
 @main.route('/')
 def home():
-    events = Event.query.order_by(Event.date).all()
+    location = request.args.get('location')
+    date = request.args.get('date', datetime.now().strftime('%Y-%m-%d'))
+    date = datetime.strptime(date, '%Y-%m-%d')
+
+    if location:
+        events = Event.query.filter(Event.location == location, Event.date >= date).order_by(Event.date).all()
+    else:
+        events = Event.query.filter(Event.date >= date).order_by(Event.date).all()
+        if len(events) > 10:
+            events = random.sample(events, 10)
+
     return render_template('home.html', events=events)
 
 @main.route('/create_event', methods=['GET', 'POST'])

--- a/meetup_clone/app/templates/home.html
+++ b/meetup_clone/app/templates/home.html
@@ -2,6 +2,27 @@
 
 {% block content %}
 <h1 class="title">イベントを探す</h1>
+
+<form method="GET" action="{{ url_for('main.home') }}">
+    <div class="field">
+        <label class="label">Location</label>
+        <div class="control">
+            <input class="input" type="text" name="location" placeholder="Enter location">
+        </div>
+    </div>
+    <div class="field">
+        <label class="label">Date</label>
+        <div class="control">
+            <input class="input" type="date" name="date">
+        </div>
+    </div>
+    <div class="field">
+        <div class="control">
+            <button class="button is-primary" type="submit">Search</button>
+        </div>
+    </div>
+</form>
+
 <div class="columns is-multiline">
     {% for event in events %}
     <div class="column is-one-third">


### PR DESCRIPTION
Implement event filtering based on location and date in the home route.

* Modify `home` route in `meetup_clone/app/routes.py` to filter events based on location and date.
  * If no location is specified, show a random selection of 10 events.
  * Exclude past events from the default event list.
* Add a search form in `meetup_clone/app/templates/home.html` to filter events by location and date.
* Update the event list in `home.html` to display filtered events.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/magusCoder-official/japanese-meetup-clone?shareId=e3767dd4-10fd-4f7a-afaf-e76ac8e53c68).