### PR TITLE
Add subject field to events

### DIFF
--- a/meetup_clone/app/forms.py
+++ b/meetup_clone/app/forms.py
@@ -11,6 +11,7 @@ class EventForm(FlaskForm):
     host_phone = StringField('Host Phone', validators=[DataRequired(), Length(max=15)])
     sub_host_email = StringField('Sub Host Email', validators=[Email()])
     sub_host_phone = StringField('Sub Host Phone', validators=[Length(max=15)])
+    subject = StringField('Subject', validators=[Length(max=100)])  # Added subject field
     submit = SubmitField('Create Event')
 
 class RegisterForm(FlaskForm):

--- a/meetup_clone/app/models.py
+++ b/meetup_clone/app/models.py
@@ -27,6 +27,7 @@ class Event(db.Model):
     host_phone = db.Column(db.String(15), nullable=False)
     sub_host_email = db.Column(db.String(120))
     sub_host_phone = db.Column(db.String(15))
+    subject = db.Column(db.String(100))  # Added subject field
     organizer_id = db.Column(db.Integer, db.ForeignKey('user.id'), nullable=False)
 
 @login_manager.user_loader

--- a/meetup_clone/app/routes.py
+++ b/meetup_clone/app/routes.py
@@ -37,6 +37,7 @@ def create_event():
                       host_phone=form.host_phone.data,
                       sub_host_email=form.sub_host_email.data,
                       sub_host_phone=form.sub_host_phone.data,
+                      subject=form.subject.data,
                       organizer=current_user)
         db.session.add(event)
         db.session.commit()

--- a/meetup_clone/app/templates/create_event.html
+++ b/meetup_clone/app/templates/create_event.html
@@ -53,6 +53,12 @@
         </div>
     </div>
     <div class="field">
+        {{ form.subject.label(class="label") }}
+        <div class="control">
+            {{ form.subject(class="input") }}
+        </div>
+    </div>
+    <div class="field">
         <div class="control">
             {{ form.submit(class="button is-primary") }}
         </div>

--- a/meetup_clone/app/templates/event_details.html
+++ b/meetup_clone/app/templates/event_details.html
@@ -5,6 +5,7 @@
 <p class="subtitle">{{ event.date.strftime('%Y年%m月%d日 %H:%M') }}</p>
 <p><strong>場所:</strong> {{ event.location }}</p>
 <p><strong>主催者:</strong> {{ event.organizer.username }}</p>
+<p><strong>Subject:</strong> {{ event.subject }}</p>
 <div class="content">
     {{ event.description }}
 </div>

--- a/meetup_clone/app/templates/home.html
+++ b/meetup_clone/app/templates/home.html
@@ -31,6 +31,7 @@
                 <p class="title is-4">{{ event.title }}</p>
                 <p class="subtitle is-6">{{ event.date.strftime('%Y年%m月%d日 %H:%M') }}</p>
                 <p>{{ event.location }}</p>
+                <p><strong>Subject:</strong> {{ event.subject }}</p>
             </div>
             <footer class="card-footer">
                 <a href="{{ url_for('main.event_details', event_id=event.id) }}" class="card-footer-item">詳細を見る</a>


### PR DESCRIPTION
Add a subject field to events to help recommend appropriate events based on subject.

* **Model Changes:**
  - Add `subject` field to the `Event` model in `meetup_clone/app/models.py`.

* **Form Changes:**
  - Add `subject` field to the `EventForm` class in `meetup_clone/app/forms.py`.

* **Route Changes:**
  - Handle `subject` field in the `create_event` route in `meetup_clone/app/routes.py`.

* **Template Changes:**
  - Display `subject` field in the `create_event.html` template in `meetup_clone/app/templates/create_event.html`.
  - Display `subject` field in the `event_details.html` template in `meetup_clone/app/templates/event_details.html`.
  - Display `subject` field in the `home.html` template in `meetup_clone/app/templates/home.html`.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/magusCoder-official/japanese-meetup-clone?shareId=7e31e49d-9c61-4f33-992b-9161182963a7).