### PR TITLE
Use SQLlitedb and sqlalchemy for database interaction

### DIFF
--- a/meetup_clone/config.py
+++ b/meetup_clone/config.py
@@ -2,5 +2,5 @@ import os
 
 class Config:
     SECRET_KEY = os.environ.get('SECRET_KEY') or 'your-secret-key'
-    SQLALCHEMY_DATABASE_URI = os.environ.get('DATABASE_URL') or 'sqlite:///meetup_clone.db'
+    SQLALCHEMY_DATABASE_URI = 'sqlite:///meetup_clone.db'
     SQLALCHEMY_TRACK_MODIFICATIONS = False


### PR DESCRIPTION
Update `Config` class in `meetup_clone/config.py` to use SQLite database for SQLAlchemy.

* Change `SQLALCHEMY_DATABASE_URI` to 'sqlite:///meetup_clone.db' instead of using environment variable or default value.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/magusCoder-official/japanese-meetup-clone?shareId=ea3a4113-950f-412c-a120-9d3633d5eb49).