### PR TITLE
Add JWT authentication and token check on app open

### DIFF
--- a/meetup_clone/app/__init__.py
+++ b/meetup_clone/app/__init__.py
@@ -1,6 +1,7 @@
 from flask import Flask
 from flask_sqlalchemy import SQLAlchemy
 from flask_login import LoginManager
+from flask_jwt_extended import JWTManager
 from config import Config
 
 db = SQLAlchemy()
@@ -13,6 +14,8 @@ def create_app():
     db.init_app(app)
     login_manager.init_app(app)
     login_manager.login_view = 'auth.login'
+
+    jwt = JWTManager(app)
 
     from app.routes.main import main
     from app.routes.auth import auth

--- a/meetup_clone/app/routes/main.py
+++ b/meetup_clone/app/routes/main.py
@@ -5,11 +5,13 @@ from app.forms import EventForm
 from app import db
 from datetime import datetime
 import random
+from app.routes.auth import check_jwt
 
 main = Blueprint('main', __name__)
 
 @main.route('/')
 def home():
+    check_jwt()
     location = request.args.get('location')
     date = request.args.get('date', datetime.now().strftime('%Y-%m-%d'))
     date = datetime.strptime(date, '%Y-%m-%d')

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ Flask-Migrate
 Flask-JWT-Extended
 flask-login
 Flask-WTF
+flask_jwt_extended


### PR DESCRIPTION
Implement JWT token check on app open and redirect to login page if not logged in.

* **Add `flask_jwt_extended` dependency:**
  - Add `flask_jwt_extended` to `requirements.txt`.

* **Initialize JWTManager:**
  - Import `JWTManager` from `flask_jwt_extended` in `meetup_clone/app/__init__.py`.
  - Initialize `JWTManager` with the Flask app instance.

* **Modify authentication routes:**
  - Import `jwt_required`, `create_access_token`, and `get_jwt_identity` from `flask_jwt_extended` in `meetup_clone/app/routes/auth.py`.
  - Modify the `login` function to create and return a JWT token upon successful login.
  - Add a new function `check_jwt` to check the JWT token on app open.

* **Update main route:**
  - Import the `check_jwt` function from `auth.py` in `meetup_clone/app/routes/main.py`.
  - Call the `check_jwt` function in the `home` route to validate the JWT token and redirect to the login page if the token is invalid or not present.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/magusCoder-official/japanese-meetup-clone?shareId=9ae23585-5221-48a7-a3ea-0d05a04aa22c).